### PR TITLE
Appdata related patches

### DIFF
--- a/data/dev.mufeed.Wordbook.metainfo.xml.in.in
+++ b/data/dev.mufeed.Wordbook.metainfo.xml.in.in
@@ -21,6 +21,9 @@
     </description>
 
     <developer_name>Mufeed Ali</developer_name>
+    <developer id="io.github.mufeedali">
+        <name translate="no">Mufeed Ali</name>
+    </developer>
     <update_contact>mufeed@kumo.foo</update_contact>
 
     <url type="homepage">https://github.com/mufeedali/Wordbook</url>

--- a/data/dev.mufeed.Wordbook.metainfo.xml.in.in
+++ b/data/dev.mufeed.Wordbook.metainfo.xml.in.in
@@ -49,7 +49,7 @@
 
     <releases>
         <release version="0.4.0" date="2023-09-25">
-            <description translatable="no">
+            <description translate="no">
                 <ul>
                     <li>GTK4 + libadwaita Port</li>
                     <li>Persistent history storage</li>
@@ -59,7 +59,7 @@
             </description>
         </release>
         <release version="0.3.1" date="2021-06-06">
-            <description translatable="no">
+            <description translate="no">
                 <ul>
                     <li>Made some minor tweaks to the UI</li>
                     <li>Fixed search entry focus on launch</li>
@@ -67,7 +67,7 @@
             </description>
         </release>
         <release version="0.3.0" date="2021-04-30">
-            <description translatable="no">
+            <description translate="no">
                 <ul>
                     <li>Switched to a brand new icon</li>
                     <li>Moved history from completions to a new sidebar</li>
@@ -78,7 +78,7 @@
             </description>
         </release>
         <release version="0.2.0" date="2021-03-08">
-            <description translatable="no">
+            <description translate="no">
                 <ul>
                     <li>Updated WordNet dependency, will need a redownload of the database</li>
                     <li>Fixed symbolic icon issues</li>
@@ -90,7 +90,7 @@
             </description>
         </release>
         <release version="0.1.0" date="2021-02-02">
-            <description translatable="no">
+            <description translate="no">
                 <p>Initial release</p>
             </description>
         </release>


### PR DESCRIPTION
### appdata: translate=no properties

It appears that the appstream project no longer supports
`translatable=no` properties, and gettext extract them as translatable.

I opened an issue to inform about the situation, but `translatable=no`
properties are not accepted by developers. You can find the issue
here: `https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### appdata: Add developer ID

Flathub requires a developer tag and developer ID. Also Appstream decided to use rdns structure for developer ID.

It allows reverse-dns IDs like sh.cozy, de.geigi or Fediverse handle (like @user@example.org)

> A developer tag with a name child tag must be present.
> Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```
Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

Source: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer