### PR TITLE
Remove encoding from .desktop file

### DIFF
--- a/data/dev.mufeed.Wordbook.desktop.in.in
+++ b/data/dev.mufeed.Wordbook.desktop.in.in
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Version=1.0
 Name=Wordbook
 Exec=wordbook


### PR DESCRIPTION
The Encoding key is deprecated in the FreeDesktop standard. Instead, all strings must now be encoded in UTF-8. This desktop entry specifies an Encoding of UTF-8.

Please refer to https://specifications.freedesktop.org/desktop-entry-spec/latest/apc.html for details.